### PR TITLE
Don't change priority of autop filters

### DIFF
--- a/inc/filters.php
+++ b/inc/filters.php
@@ -21,11 +21,6 @@ class UW_Filters
         add_filter( 'excerpt_more', '__return_false' );
         add_filter( 'the_excerpt', array( $this, 'excerpt_more_override' ) );
 
-        //remove auto-paragraphs from shortcodes and keep it for content
-        remove_filter( 'the_content', 'wpautop' );
-        add_filter( 'the_content', 'wpautop', 99 );
-        add_filter( 'the_content', 'shortcode_unautop', 100 );
-
         // Add PDF filter to media library
         add_filter( 'post_mime_types', array( $this, 'modify_post_mime_types' ) );
 

--- a/inc/shortcodes/class.accordion-shortcode.php
+++ b/inc/shortcodes/class.accordion-shortcode.php
@@ -10,18 +10,10 @@
  * [/accordion]
  */
 class UW_Accordion {
-	const PRIORITY = 12;
-
 	/**
 	 * Accordion constructor.
 	 */
 	public function __construct() {
-		remove_filter( 'the_content', 'wpautop' );
-		add_filter( 'the_content', 'wpautop', self::PRIORITY );
-
-		remove_filter( 'the_excerpt', 'wpautop' );
-		add_filter( 'the_excerpt', 'wpautop', self::PRIORITY );
-
 		add_shortcode( 'accordion', array( $this, 'accordion_handler' ) );
 		add_shortcode( 'section', array( $this, 'section_handler' ) );
 		add_shortcode( 'subsection', array( $this, 'subsection_handler' ) );

--- a/inc/shortcodes/class.blockquote-shortcode.php
+++ b/inc/shortcodes/class.blockquote-shortcode.php
@@ -6,15 +6,10 @@
  * [blockquote style="" align="" name="Dubs Husky" title="Official Live Mascot"] blockquote text [/blockquote]
  */
 class UW_Blockquote {
-	const PRIORITY = 12;
-
 	/**
 	 * Blockquote constructor.
 	 */
 	public function __construct() {
-		remove_filter( 'the_content', 'wpautop' );
-		add_filter( 'the_content', 'wpautop', self::PRIORITY );
-
 		add_shortcode( 'blockquote', array( $this, 'blockquote_handler' ) );
 	}
 

--- a/inc/shortcodes/class.tabs-tours-shortcode.php
+++ b/inc/shortcodes/class.tabs-tours-shortcode.php
@@ -10,15 +10,10 @@
  * [/uw_tabs]
  */
 class UW_Tabs_Tours {
-	const PRIORITY = 12;
-
 	/**
 	 * Tabs constructor.
 	 */
 	public function __construct() {
-		remove_filter( 'the_content', 'wpautop' );
-		add_filter( 'the_content', 'wpautop', self::PRIORITY );
-
 		add_shortcode( 'uw_tabs', array( $this, 'tabs_tours_handler' ) );
 		add_shortcode( 'tabs_section', array( $this, 'tabs_section_handler' ) );
 

--- a/inc/shortcodes/class.tile-box-shortcode.php
+++ b/inc/shortcodes/class.tile-box-shortcode.php
@@ -10,16 +10,11 @@
 class UW_TileBox
 {
 	const MAXTILES = 12;
-	const PRIORITY = 11;
 	private $count = 0;
 	private $NumbersArray = array('zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven', 'twelve'); //arrays can't be constants in PHP.  Privates at least can't be changed
 
 	function __construct()
 	{
-		remove_filter( 'the_content', 'wpautop' );
-		add_filter( 'the_content', 'wpautop' , self::PRIORITY );
-		remove_filter( 'the_excerpt', 'wpautop' );
-		add_filter( 'the_excerpt', 'wpautop' , self::PRIORITY );
 		add_shortcode( 'box', array( $this, 'box_handler' ) );
 		add_shortcode( 'tile', array( $this, 'tile_handler' ) );
 	}


### PR DESCRIPTION
Adding the wpautop filter where it wouldn't be normally used, or changing its priority, will causes extraneous paragraph and line break tags to be inserted into already rendered elements from plugins, etc. leading to breakage in unpredictable ways, see #78

Wordpress adds these filters by default, in the correct order to make sure that rendered elements don't get unwanted tags added to them. Note that the "content" of shortcodes isn't excluded and will still get these tags where appropriate.

This just returns the UW theme to using that default filtering. I wasn't able to see any change in the appearance of the UW shortcodes.
