### PR TITLE
Fix deprecation warnings on PHP 8.1

### DIFF
--- a/inc/wp-bootstrap-megamenu-navwalker.php
+++ b/inc/wp-bootstrap-megamenu-navwalker.php
@@ -151,7 +151,7 @@ if ( ! class_exists( 'Bootstrap_MegaMenu_Walker' ) ) {
 		 * Display Element
 		 *
 		 */
-		public function display_element( $element, &$children_elements, $max_depth, $depth = 0, $args, &$output ) {
+		public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
 			if ( ! $element ) {
 				return;
 			}


### PR DESCRIPTION
Because the $depth argument to display_element is optional (has a default value of 0) it doesn't make sense for the following options to be required (no default value), so this results in warnings like:

Deprecated: Required parameter ... follows optional parameter ...

Since the $depth parameter is not optional in the parent classes (in WP core), and it's not really possible for any caller to leave it out anyway, just put it back to required.